### PR TITLE
Remove executed condition from indexes

### DIFF
--- a/libraries/eosiolib/wasmql/eosio/database.hpp
+++ b/libraries/eosiolib/wasmql/eosio/database.hpp
@@ -335,8 +335,7 @@ struct query_block_info_range_index {
     uint32_t max_results = {};
 };
 
-/// Pass this to `query_database` to get `action_trace` for a range of keys. Only includes actions
-/// in executed transactions.
+/// Pass this to `query_database` to get `action_trace` for a range of keys.
 ///
 /// The query results are sorted by `key`. Every record has a different key.
 /// ```c++
@@ -352,7 +351,7 @@ struct query_block_info_range_index {
 ///     static key from_data(const action_trace& data);
 /// };
 /// ```
-struct query_action_trace_executed_range_name_receiver_account_block_trans_action {
+struct query_action_trace_range_name_receiver_account_block_trans_action {
     struct key {
         eosio::name name           = {};
         eosio::name receiver       = {};
@@ -391,7 +390,7 @@ struct query_action_trace_executed_range_name_receiver_account_block_trans_actio
 };
 
 /// \group increment_key
-inline bool increment_key(query_action_trace_executed_range_name_receiver_account_block_trans_action::key& key) {
+inline bool increment_key(query_action_trace_range_name_receiver_account_block_trans_action::key& key) {
     return increment_key(key.action_ordinal) && //
            increment_key(key.transaction_id) && //
            increment_key(key.block_num) &&      //

--- a/src/init.sql
+++ b/src/init.sql
@@ -1,32 +1,26 @@
 
 
-        create index if not exists at_executed_range_name_receiver_account_block_trans_action_idx on chain.action_trace(
+        create index if not exists at_range_name_receiver_account_block_trans_action_idx on chain.action_trace(
             "act_name",
             "receiver",
             "act_account",
             "block_num",
             "transaction_id",
             "action_ordinal"
-        )
-        where
-            transaction_status = 'executed';
+        );
 
-        create index if not exists executed_receipt_receiver_idx on chain.action_trace(
+        create index if not exists receipt_receiver_idx on chain.action_trace(
             "receiver",
             "block_num",
             "transaction_id",
             "action_ordinal"
-        )
-        where
-            transaction_status = 'executed';
+        );
 
-        create index if not exists executed_transaction_idx on chain.action_trace(
+        create index if not exists transaction_idx on chain.action_trace(
             "transaction_id",
             "block_num",
             "action_ordinal"
-        )
-        where
-            transaction_status = 'executed';
+        );
 
         create index if not exists account_name_block_present_idx on chain.account(
             "name",
@@ -108,7 +102,6 @@
                     where
                         ("block_num") >= ("arg_first_block_num")
                         
-                        
                     order by
                         "block_num"
                     limit max_results
@@ -122,8 +115,8 @@
             end 
         $$ language plpgsql;
     
-        drop function if exists chain.at_executed_range_name_receiver_account_block_trans_action;
-        create function chain.at_executed_range_name_receiver_account_block_trans_action(
+        drop function if exists chain.at_range_name_receiver_account_block_trans_action;
+        create function chain.at_range_name_receiver_account_block_trans_action(
             max_block_num bigint,
             first_act_name varchar(13),
             first_receiver varchar(13),
@@ -163,8 +156,6 @@
                         chain.action_trace
                     where
                         ("act_name","receiver","act_account","block_num","transaction_id","action_ordinal") >= ("arg_first_act_name", "arg_first_receiver", "arg_first_act_account", "arg_first_block_num", "arg_first_transaction_id", "arg_first_action_ordinal")
-                        and transaction_status = 'executed'
-                        
                         and action_trace.block_num <= max_block_num
                     order by
                         "act_name","receiver","act_account","block_num","transaction_id","action_ordinal"
@@ -179,8 +170,8 @@
             end 
         $$ language plpgsql;
     
-        drop function if exists chain.executed_receipt_receiver;
-        create function chain.executed_receipt_receiver(
+        drop function if exists chain.receipt_receiver;
+        create function chain.receipt_receiver(
             max_block_num bigint,
             first_receiver varchar(13),
             first_block_num bigint,
@@ -212,8 +203,6 @@
                         chain.action_trace
                     where
                         ("receiver","block_num","transaction_id","action_ordinal") >= ("arg_first_receiver", "arg_first_block_num", "arg_first_transaction_id", "arg_first_action_ordinal")
-                        and transaction_status = 'executed'
-                        
                         and action_trace.block_num <= max_block_num
                     order by
                         "receiver","block_num","transaction_id","action_ordinal"
@@ -228,8 +217,8 @@
             end 
         $$ language plpgsql;
     
-        drop function if exists chain.executed_transaction;
-        create function chain.executed_transaction(
+        drop function if exists chain.transaction;
+        create function chain.transaction(
             max_block_num bigint,
             first_transaction_id varchar(64),
             first_block_num bigint,
@@ -257,8 +246,6 @@
                         chain.action_trace
                     where
                         ("transaction_id","block_num","action_ordinal") >= ("arg_first_transaction_id", "arg_first_block_num", "arg_first_action_ordinal")
-                        and transaction_status = 'executed'
-                        
                         and action_trace.block_num <= max_block_num
                     order by
                         "transaction_id","block_num","action_ordinal"

--- a/src/query-config.json
+++ b/src/query-config.json
@@ -858,7 +858,7 @@
         },
         {
             "short_name": "at.e.nra",
-            "index": "at_executed_range_name_receiver_account_block_trans_action_idx",
+            "index": "at_range_name_receiver_account_block_trans_action_idx",
             "table": "action_trace",
             "sort_keys": [
                 {
@@ -879,14 +879,11 @@
                 {
                     "name": "action_ordinal"
                 }
-            ],
-            "conditions": [
-                "transaction_status = 'executed'"
             ]
         },
         {
             "short_name": "receipt.rcvr",
-            "index": "executed_receipt_receiver_idx",
+            "index": "receipt_receiver_idx",
             "table": "action_trace",
             "sort_keys": [
                 {
@@ -901,14 +898,11 @@
                 {
                     "name": "action_ordinal"
                 }
-            ],
-            "conditions": [
-                "transaction_status = 'executed'"
             ]
         },
         {
             "short_name": "transaction",
-            "index": "executed_transaction_idx",
+            "index": "transaction_idx",
             "table": "action_trace",
             "sort_keys": [
                 {
@@ -920,9 +914,6 @@
                 {
                     "name": "action_ordinal"
                 }
-            ],
-            "conditions": [
-                "transaction_status = 'executed'"
             ]
         },
         {
@@ -1278,24 +1269,24 @@
         },
         {
             "wasm_name": "at.e.nra",
-            "index": "at_executed_range_name_receiver_account_block_trans_action_idx",
-            "function": "at_executed_range_name_receiver_account_block_trans_action",
+            "index": "at_range_name_receiver_account_block_trans_action_idx",
+            "function": "at_range_name_receiver_account_block_trans_action",
             "table": "action_trace",
             "max_results": 100,
             "limit_block_num": true
         },
         {
             "wasm_name": "receipt.rcvr",
-            "index": "executed_receipt_receiver_idx",
-            "function": "executed_receipt_receiver",
+            "index": "receipt_receiver_idx",
+            "function": "receipt_receiver",
             "table": "action_trace",
             "max_results": 100,
             "limit_block_num": true
         },
         {
             "wasm_name": "transaction",
-            "index": "executed_transaction_idx",
-            "function": "executed_transaction",
+            "index": "transaction_idx",
+            "function": "transaction",
             "table": "action_trace",
             "max_results": 100,
             "limit_block_num": true

--- a/src/query_config.hpp
+++ b/src/query_config.hpp
@@ -78,7 +78,6 @@ struct index {
     bool                             include_in_pg = {};
     bool                             only_for_trim = {};
     std::vector<typename Defs::key>  sort_keys     = {};
-    std::vector<std::string>         conditions    = {};
     std::vector<typename Defs::type> range_types   = {};
     typename Defs::table*            table_obj     = {};
 };
@@ -91,7 +90,6 @@ constexpr void for_each_field(index<Defs>*, F f) {
     ABIEOS_MEMBER(index<Defs>, include_in_pg);
     ABIEOS_MEMBER(index<Defs>, only_for_trim);
     ABIEOS_MEMBER(index<Defs>, sort_keys);
-    ABIEOS_MEMBER(index<Defs>, conditions);
 };
 
 template <typename Defs>

--- a/wasms/token/token-server.cpp
+++ b/wasms/token/token-server.cpp
@@ -13,7 +13,7 @@ struct transfer {
 };
 
 void process(token_transfer_request& req, const eosio::database_status& status) {
-    using query_type = eosio::query_action_trace_executed_range_name_receiver_account_block_trans_action;
+    using query_type = eosio::query_action_trace_range_name_receiver_account_block_trans_action;
     auto s           = query_database(query_type{
         .max_block = get_block_num(req.max_block, status),
         .first =
@@ -41,6 +41,8 @@ void process(token_transfer_request& req, const eosio::database_status& status) 
     std::optional<query_type::key> last_key;
     eosio::for_each_query_result<eosio::action_trace>(s, [&](eosio::action_trace& at) {
         last_key = query_type::key::from_data(at);
+        if (at.transaction_status != eosio::transaction_status::executed)
+            return true;
 
         // todo: handle bad unpack
         auto unpacked = eosio::unpack<transfer>(at.action.data->pos(), at.action.data->remaining());


### PR DESCRIPTION
Action indexes and queries had a built-in condition to only return executed actions. This reduced flexibility and was only implemented in PostgresQL. This created an inconsistency with the (now removed) lmdb and (newly-added) rocksdb implementations.
