### PR TITLE
Push history-tools to Dockerhub

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -4,7 +4,8 @@ steps:
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
     command:
-      - "docker build -f ./ubuntu-18.04.dockerfile ."
+      - "docker build -t eosio/history-tools:$BUILDKITE_COMMIT -f ./ubuntu-18.04.dockerfile ."
+      - "docker push eosio/history-tools:$BUILDKITE_COMMIT"
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents:


### PR DESCRIPTION
The `eosio/history-tools` Dockerhub repository already exists. These changes should now tag the build container appropriately and push when a container build is successful.