### PR TITLE
fill-pg integration test

### DIFF
--- a/.cicd/helpers/create_env_file.sh
+++ b/.cicd/helpers/create_env_file.sh
@@ -1,0 +1,8 @@
+#create .env file for docker-compose up command
+echo "SNAPSHOT_FILE=$(pwd)/snapshots/$(ls snapshots)" > .env
+echo "PEER_ADDR=seed.testnet.eos.io:9876" >> .env
+echo "DOCKER_EOSIO_TAG=develop" >> .env
+
+if [[ "$BUILDKITE" == 'true' ]]; then
+  echo "DOCKER_HISTORY_TOOLS_TAG=$BUILDKITE_COMMIT" >> .env
+fi

--- a/.cicd/helpers/execute_test.sh
+++ b/.cicd/helpers/execute_test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [[ "$BUILDKITE" == 'true' ]]; then
+  apt-get update && apt-get -y install wget
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+bash $DIR/get_snapshot.sh
+bash $DIR/create_env_file.sh
+
+docker-compose up -d
+
+for (( ; ; ))
+do
+  #check if there is data in database
+  POSTGRES_CONTAINER_ID=`docker-compose ps -q postgres`
+  BLOCK_INFO_ROWS_COUNT=`docker exec -it $POSTGRES_CONTAINER_ID psql -c 'SELECT block_num FROM chain.block_info limit 5;'`
+  if [[ $BLOCK_INFO_ROWS_COUNT =~ "5 rows" ]]; then
+    #get block #s and check they are in ascending order
+
+    BLOCK_INFO_ROWS_CONTENT=`docker exec -it $POSTGRES_CONTAINER_ID psql -t -c 'SELECT array( SELECT block_num FROM chain.block_info limit 5 );'`
+
+    BLOCK_INFO_ROWS_CONTENT=`echo $BLOCK_INFO_ROWS_CONTENT | tr -d '{}'`
+
+    LATEST_BLOCK=0
+    while IFS=',' read -ra ADDR; do
+      for CURRENT_BLOCK in "${ADDR[@]}"; do
+        if [ $LATEST_BLOCK -gt $CURRENT_BLOCK ]; then
+          exit 1
+        fi
+        LATEST_BLOCK=$CURRENT_BLOCK
+      done
+    done <<< "$BLOCK_INFO_ROWS_CONTENT"
+
+    echo "Succesful test"
+    break
+  fi
+  sleep 5
+done

--- a/.cicd/helpers/execute_test.sh
+++ b/.cicd/helpers/execute_test.sh
@@ -8,10 +8,6 @@ function execute-psql-command(){
   RET_SQL_CMD=`eval $CMD`
 }
 
-if [[ "$BUILDKITE" == 'true' ]]; then
-    apt-get update && apt-get -y install wget
-fi
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 bash $DIR/get_snapshot.sh

--- a/.cicd/helpers/get_snapshot.sh
+++ b/.cicd/helpers/get_snapshot.sh
@@ -1,0 +1,23 @@
+#get xml with info about snapshots
+wget -O snapshots.xml https://snapshot.testnet.eos.io
+
+#parse xml to get latest snaspshot
+read_dom () {
+    local IFS=\>
+    read -d \< ENTITY CONTENT
+}
+
+LATEST_SNAPSHOT=""
+
+while read_dom; do
+    if [[ $ENTITY = "Key" ]]; then
+      if [[ $CONTENT =~ "snapshots" ]]; then
+        LATEST_SNAPSHOT=$CONTENT
+      fi
+    fi
+done < snapshots.xml
+
+#get actual snapshot file and unzip
+wget https://snapshot.testnet.eos.io/$LATEST_SNAPSHOT
+tar -xzvf snapshots.tar.gz
+

--- a/.cicd/helpers/get_snapshot.sh
+++ b/.cicd/helpers/get_snapshot.sh
@@ -1,5 +1,5 @@
 #get xml with info about snapshots
-wget -O snapshots.xml https://snapshot.testnet.eos.io
+curl -L https://snapshot.testnet.eos.io > snapshots.xml
 
 #parse xml to get latest snaspshot
 read_dom () {
@@ -18,6 +18,5 @@ while read_dom; do
 done < snapshots.xml
 
 #get actual snapshot file and unzip
-wget https://snapshot.testnet.eos.io/$LATEST_SNAPSHOT
-tar -xzvf snapshots.tar.gz
+curl -L https://snapshot.testnet.eos.io/$LATEST_SNAPSHOT | tar -xzf -
 

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,5 +10,15 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-15}
+    skip: $SKIP_UBUNTU_18
+
+  - wait
+
+  - label: "run integration test"
+    command:
+      - "./.cicd/helpers/execute_test.sh"
+    agents:
+      queue: "automation-eks-eos-builder-fleet"
+    timeout: ${TIMEOUT:-15}
     skip: $SKIP_UBUNTU_18

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.3"
+
+services:
+  nodeos:
+    image: docker.io/eosio/eos:${DOCKER_EOSIO_TAG:-develop}
+    command:
+      - nodeos
+      - --plugin
+      - eosio::producer_plugin
+      - --plugin
+      - eosio::chain_api_plugin
+      - --plugin
+      - eosio::http_plugin
+      - --plugin
+      - eosio::producer_api_plugin
+      - --chain-state-db-size-mb
+      - "65536"
+      - --plugin
+      - eosio::state_history_plugin
+      - --state-history-endpoint
+      - 0.0.0.0:8080
+      - --trace-history
+      - --chain-state-history
+      - --disable-replay-opts
+      - --p2p-peer-address=${PEER_ADDR:-seed.testnet.eos.io:9876}
+      - --snapshot
+      - /snapshots/snapshot.bin
+    volumes:
+      - type: bind
+        source: ${SNAPSHOT_FILE:-./snapshot.bin}
+        target: /snapshots/snapshot.bin
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=password
+  history-tools:
+    image: eosio/history-tools:${DOCKER_HISTORY_TOOLS_TAG:-latest}
+    command:
+      - ./fill-pg
+      - --fpg-create
+      - --fill-connect-to=nodeos:8080
+    environment:
+      - PGUSER=root
+      - PGPASSWORD=password
+      - PGHOST=postgres
+    restart: always
+    depends_on:
+      - postgres
+      - nodeos


### PR DESCRIPTION
Add an integration test for fill-pg using this logic:

- Get a snapshot from https://testnet.eos.io/
- Using docker-composer create 3 containers: the first for containing nodeos started with the snapshot we downloaded, the second containing the postgres instance used by fill-pg, and one for containing the history-tools container which builds the fill-pg executable.
- After the 3 containers are up, a query is done on the postgres container until the chain.block_info table has 5 elements and we also check that they are in ascending order.

The composer-docker.yml file can use these environment variables:

- DOCKER_EOSIO_TAG, tag used for the eosio container
- PEER_ADDR, ip address of p2p peer for syncing the blockchain initiated on eosio container
- SNAPSHOT_FILE, path to the snapshot for the blockchain initiated on eosio container
- DOCKER_HISTORY_TOOLS_TAG, tag used for the history-tools container