### PR TITLE
fix: update eosio::checksum256 .size() to sizeof

### DIFF
--- a/src/state_history_pg.hpp
+++ b/src/state_history_pg.hpp
@@ -41,7 +41,7 @@ inline eosio::checksum256 sql_to_checksum256(const char* ch) {
     eosio::checksum256 result;
     if (v.size() != sizeof(result.value))
         throw std::runtime_error("hex string has incorrect length");
-    memcpy(result.value.data(), v.data(), result.value.size());
+    memcpy(result.value.data(), v.data(), sizeof(result.value));
     return result;
 }
 

--- a/src/state_history_pg.hpp
+++ b/src/state_history_pg.hpp
@@ -39,7 +39,7 @@ inline eosio::checksum256 sql_to_checksum256(const char* ch) {
     std::vector<uint8_t> v;
     boost::algorithm::unhex(ch, ch + strlen(ch), std::back_inserter(v));
     eosio::checksum256 result;
-    if (v.size() != result.value.size())
+    if (v.size() != sizeof(result.value))
         throw std::runtime_error("hex string has incorrect length");
     memcpy(result.value.data(), v.data(), result.value.size());
     return result;


### PR DESCRIPTION
When restarting fill-pg we get the following error:

error 2022-01-12T19:31:44.613 thread-0  state_history_connecti:179    catch_and_close      ] hex string has incorrect length

This is due to a mismatch between comparing the length of an array with the real size in memory of the data.

I created a new PR from https://github.com/EOSIO/history-tools/pull/131, to address each of the issues on that PR separately.